### PR TITLE
don't leak contexts

### DIFF
--- a/04-reqres/node.rb
+++ b/04-reqres/node.rb
@@ -78,10 +78,9 @@ class Node
 
   def remote_call(remote, message)
     puts "#{remote} <= #{message}"
-    req = connect(ZMQ::REQ, config("port", remote), config("ip", remote))
-    resp = req.send(message) && req.recv
-    req.close
-    resp
+    communicate(ZMQ::REQ, config("port", remote), config("ip", remote)) do |req|
+      req.send(message) && req.recv
+    end
   end
 end
 

--- a/04-reqres/services.rb
+++ b/04-reqres/services.rb
@@ -7,10 +7,19 @@
 # calling and passed to the method
 module Services
   def connect(kind, port=2200, ip='127.0.0.1')
-    ctx = ZMQ::Context.new
-    sock = ctx.socket(kind)
+    @ctx ||= ZMQ::Context.new
+    sock = @ctx.socket(kind)
     sock.connect("tcp://#{ip}:#{port}")
     sock
+  end
+
+  def communicate(kind, port, ip)
+    @ctx ||= ZMQ::Context.new
+    sock = @ctx.socket(kind)
+    sock.connect("tcp://#{ip}:#{port}")
+    resp = yield sock
+    sock.close
+    resp
   end
 
   # helper function to create a req/res service,


### PR DESCRIPTION
Hello,
these examples are great.
# Problem

On my computer, after 42 put requests, it runs out of file descriptors, because too many contexts are created and not cleaned up.

I interpret [guide](http://zguide.zeromq.org/page:all#Getting-the-Context-Right) to say you need only 1 context per process, except in rare cases. Don't know enough to elaborate the rare cases. But not terminating the context isn't good.
# Suggested Solution

I modified `connect` to cache the context in the process, and everything runs great on my machine.

Played around with using the block / auto close syntax and liked it.

I can change pull request and fix bug across all examples but requesting your preference:
- `@ctx` variable vs passing `context` in
- `connect` and explicit `close` style vs `communicate` block style with auto closing of the socket. (if you like `communicate`, I could change `connect` to look like `communicate`)

Thanks again for the great examples. This is my first entry into zeromq.
--Keenan
